### PR TITLE
Subtyping on vector types & heap bottom check

### DIFF
--- a/document/core/appendix/algorithm.rst
+++ b/document/core/appendix/algorithm.rst
@@ -67,6 +67,7 @@ Equivalence and subtyping checks can be defined on these types.
    func matches(t1 : val_type, t2 : val_type) : bool =
      return
        (is_num t1 && is_num t2 && t1 = t2) ||
+       (is_vec t1 && is_vec t2) ||
        (is_ref t1 && is_ref t2 && matches_ref(t1, t2)) ||
        t1 = Bot
 

--- a/document/core/appendix/algorithm.rst
+++ b/document/core/appendix/algorithm.rst
@@ -67,7 +67,7 @@ Equivalence and subtyping checks can be defined on these types.
    func matches(t1 : val_type, t2 : val_type) : bool =
      return
        (is_num t1 && is_num t2 && t1 = t2) ||
-       (is_vec t1 && is_vec t2) ||
+       (is_vec t1 && is_vec t2 && t1 == t2) ||
        (is_ref t1 && is_ref t2 && matches_ref(t1, t2)) ||
        t1 = Bot
 

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -929,6 +929,7 @@
 .. |vdashtabletypedefaultable| mathdef:: \xref{valid/types}{valid-defaultable}{\vdash}
 
 .. |vdashnumtypematch| mathdef:: \xref{valid/matching}{match-numtype}{\vdash}
+.. |vdashvectypematch| mathdef:: \xref{valid/matching}{match-vectype}{\vdash}
 .. |vdashheaptypematch| mathdef:: \xref{valid/matching}{match-heaptype}{\vdash}
 .. |vdashreftypematch| mathdef:: \xref{valid/matching}{match-reftype}{\vdash}
 .. |vdashvaltypematch| mathdef:: \xref{valid/matching}{match-valtype}{\vdash}

--- a/document/core/valid/matching.rst
+++ b/document/core/valid/matching.rst
@@ -26,6 +26,24 @@ A :ref:`number type <syntax-numtype>` :math:`\numtype_1` matches a :ref:`number 
    }
 
 
+.. index:: vector type
+.. _match-vectortype:
+
+Vector Types
+~~~~~~~~~~~~
+
+A :ref:`vector type <syntax-vectype>` :math:`\vectype_1` matches a :ref:`vector type <syntax-vectype>` :math:`\vectype_2` if and only if:
+
+* Both :math:`\vectype_1` and :math:`\vectype_2` are the same.
+
+.. math::
+   ~\\[-1ex]
+   \frac{
+   }{
+     C \vdashvectypematch \vectype \matchesvaltype \vectype
+   }
+
+
 .. index:: heap type
 .. _match-heaptype:
 

--- a/document/core/valid/types.rst
+++ b/document/core/valid/types.rst
@@ -87,6 +87,16 @@ Concrete :ref:`Heap types <syntax-heaptype>` are only valid when the :ref:`type 
      C \vdashheaptype \typeidx \ok
    }
 
+:math:`\BOT`
+............
+
+* The heap type is valid.
+
+.. math::
+   \frac{
+   }{
+     C \vdashheaptype \BOT \ok
+   }
 
 .. index:: reference type, heap type
    pair: validation; reference type


### PR DESCRIPTION
This patch extends the matches (subtyping) relation with a reflexive
clause for vector types. This patch also adds a missing
well-formedness definition for the bottom heap type.