### PR TITLE
Fix null subtyping being wrong way around

### DIFF
--- a/document/core/valid/matching.rst
+++ b/document/core/valid/matching.rst
@@ -106,7 +106,7 @@ A :ref:`reference type <syntax-reftype>` :math:`\REF~\NULL_1^?~heaptype_1` match
    \frac{
      C \vdashheaptypematch \heaptype_1 \matchesheaptype \heaptype_2
    }{
-     C \vdashreftypematch \REF~\NULL~\heaptype_1 \matchesreftype \REF~\NULL^?~\heaptype_2
+     C \vdashreftypematch \REF~\NULL^?~\heaptype_1 \matchesreftype \REF~\NULL~\heaptype_2
    }
 
 


### PR DESCRIPTION
The current spec text implies `T | null ≤ T` which is not correct and does not match the prose.