### PR TITLE
Update table initialization in overview

### DIFF
--- a/proposals/function-references/Overview.md
+++ b/proposals/function-references/Overview.md
@@ -64,7 +64,7 @@ It is also possible to create a typed function table:
 ```wasm
 (table 0 (ref $i32-i32))
 ```
-Such a table can neither contain `null` entries nor functions of another type. Any use of `call_indirect` on this table does hence avoid all runtime checks beyond the basic bounds check. By using multiple tables, each one can be given a homogeneous type. The table can be initialised by growing it (provding an explicit initialiser value. (Open Question: we could also extend table definitions to provide an explicit initialiser.)
+Such a table can neither contain `null` entries nor functions of another type. Any use of `call_indirect` on this table does hence avoid all runtime checks beyond the basic bounds check. By using multiple tables, each one can be given a homogeneous type. The table can be initialised with an initializer or by growing it.
 
 Typed function references are a subtype of `funcref`, so they can also be used as untyped references. All previous uses of `ref.func` remain valid:
 ```wasm


### PR DESCRIPTION
The updated spec already has table initializers (e.g. https://webassembly.github.io/function-references/core/syntax/modules.html#tables). We also have tests.