### PR TITLE
Fix formatting in the spec binary section for table initializers

### DIFF
--- a/document/core/binary/modules.rst
+++ b/document/core/binary/modules.rst
@@ -212,7 +212,7 @@ It decodes into a vector of :ref:`tables <syntax-table>` that represent the |MTA
    \production{table} & \Btable &::=&
      \X{tt}{:}\Btabletype
        &\Rightarrow& \{ \TTYPE~\X{tt}, \TINIT~(\REFNULL~\X{ht}) \}
-         \qquad \iff \X{tt} = \limits~(\REF~\NULL^?~\X{ht}) \\
+         \qquad \iff \X{tt} = \limits~(\REF~\NULL^?~\X{ht}) \\ &&|&
      \hex{40}~~\hex{00}~~\X{tt}{:}\Btabletype~~e{:}\Bexpr
        &\Rightarrow& \{ \TTYPE~\X{tt}, \TINIT~e \} \\
    \end{array}


### PR DESCRIPTION
There's some weird formatting in the description of the binary format of table initializers:

![table-screenshot-1](https://github.com/WebAssembly/function-references/assets/64192/224ba4a6-7899-450c-a0fd-d996bf039394)

This PR should fix it to look like this:

![table-screenshot-2](https://github.com/WebAssembly/function-references/assets/64192/46acc758-260a-4c07-81d4-d0f218930640)
