### PR TITLE
Fix a few minor issues in local validation rules

### DIFF
--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -212,8 +212,8 @@
 .. |MVAR| mathdef:: \xref{syntax/types}{syntax-mut}{\K{var}}
 .. |MCONST| mathdef:: \xref{syntax/types}{syntax-mut}{\K{const}}
 
-.. |SET| mathdef:: \xref{syntax/types}{syntax-init}{\mathrel{\mbox{set}}}
-.. |UNSET| mathdef:: \xref{syntax/types}{syntax-init}{\mathrel{\mbox{unset}}}
+.. |SET| mathdef:: \xref{syntax/types}{syntax-init}{\K{set}}
+.. |UNSET| mathdef:: \xref{syntax/types}{syntax-init}{\K{unset}}
 
 .. |LMIN| mathdef:: \xref{syntax/types}{syntax-limits}{\K{min}}
 .. |LMAX| mathdef:: \xref{syntax/types}{syntax-limits}{\K{max}}

--- a/document/core/valid/modules.rst
+++ b/document/core/valid/modules.rst
@@ -52,7 +52,7 @@ Functions :math:`\func` are classified by :ref:`type indices <syntax-typeidx>` r
      \qquad
      C,\CLOCALS\,(\SET~t_1)^\ast~(\init~t)^\ast,\CLABELS~[t_2^\ast],\CRETURN~[t_2^\ast] \vdashexpr \expr : [t_2^\ast]
    }{
-     C \vdashfunc \{ \FTYPE~x, \FLOCALS~t^\ast, \FBODY~\expr \} : x
+     C \vdashfunc \{ \FTYPE~x, \FLOCALS \{\LTYPE~t\}^\ast, \FBODY~\expr \} : x
    }
 
 
@@ -85,14 +85,14 @@ Locals
      \qquad
      C \vdashvaltypedefaultable t \defaultable
    }{
-     C \vdashlocal \{ \LTYPE~t \} : \SET~t \ok
+     C \vdashlocal \{ \LTYPE~t \} : \SET~t
    }
 
 .. math::
    \frac{
      C \vdashvaltype t \ok
    }{
-     C \vdashlocal \{ LTYPE~t \} : \UNSET~t \ok
+     C \vdashlocal \{ \LTYPE~t \} : \UNSET~t
    }
 
 .. note::

--- a/document/core/valid/modules.rst
+++ b/document/core/valid/modules.rst
@@ -48,11 +48,11 @@ Functions :math:`\func` are classified by :ref:`type indices <syntax-typeidx>` r
    \frac{
      C.\CTYPES[x] = [t_1^\ast] \toF [t_2^\ast]
      \qquad
-     (C \vdashlocal t : \init~t)^\ast
+     (C \vdashlocal \{\LTYPE~t\} : \init~t)^\ast
      \qquad
      C,\CLOCALS\,(\SET~t_1)^\ast~(\init~t)^\ast,\CLABELS~[t_2^\ast],\CRETURN~[t_2^\ast] \vdashexpr \expr : [t_2^\ast]
    }{
-     C \vdashfunc \{ \FTYPE~x, \FLOCALS \{\LTYPE~t\}^\ast, \FBODY~\expr \} : x
+     C \vdashfunc \{ \FTYPE~x, \FLOCALS~\{\LTYPE~t\}^\ast, \FBODY~\expr \} : x
    }
 
 


### PR DESCRIPTION
Here are the current rendered local rules:

![image](https://github.com/WebAssembly/function-references/assets/64192/252a376c-6795-49ad-a6f3-08fe17fe9503)

From this PR:

![image](https://github.com/WebAssembly/function-references/assets/64192/ee4b16ea-afac-4495-a91e-db90258eb372)

The main obvious fix is for the `LTYPE` which is misformatted. Two other fixes:

  * I suspect the `ok` in the conclusion of the validation rule isn't needed, as there's an output.
  * In the function `{ type x, locals t*, body expr }`, the `t*` are locals with shape `{type t'}` so I think there needs to be some matching on that somewhere in the rule? Here I put it in the conclusion but it could go in the premise too.

BTW: the spacing on the `set`/`unset` seem a bit off too. I think it's due to the `\mathrel` used for those keywords but wasn't sure what the preferred change was there.