### PR TITLE
[test] Unify the trap message of "null function reference".

### DIFF
--- a/test/core/call_ref.wast
+++ b/test/core/call_ref.wast
@@ -94,7 +94,7 @@
 (assert_return (invoke "run" (i32.const 0)) (i32.const 0))
 (assert_return (invoke "run" (i32.const 3)) (i32.const -9))
 
-(assert_trap (invoke "null") "null function")
+(assert_trap (invoke "null") "null function reference")
 
 (assert_return (invoke "fac" (i64.const 0)) (i64.const 1))
 (assert_return (invoke "fac" (i64.const 1)) (i64.const 1))

--- a/test/core/return_call_ref.wast
+++ b/test/core/return_call_ref.wast
@@ -180,7 +180,7 @@
 (assert_return (invoke "type-second-f32") (f32.const 32))
 (assert_return (invoke "type-second-f64") (f64.const 64.1))
 
-(assert_trap (invoke "null") "null function")
+(assert_trap (invoke "null") "null function reference")
 
 (assert_return (invoke "fac-acc" (i64.const 0) (i64.const 1)) (i64.const 1))
 (assert_return (invoke "fac-acc" (i64.const 1) (i64.const 1)) (i64.const 1))


### PR DESCRIPTION
Refer to the message in [interpreter](https://github.com/WebAssembly/function-references/blob/main/interpreter/exec/eval.ml#L229).