### PR TITLE
Test `return_call*`s to callees that return more values than the caller does

### DIFF
--- a/test/core/return_call.wast
+++ b/test/core/return_call.wast
@@ -188,7 +188,15 @@
   )
   "type mismatch"
 )
-
+(assert_invalid
+  (module
+    (func $f (result i32 i32) unreachable)
+    (func (result i32)
+      return_call $f
+    )
+  )
+  "type mismatch"
+)
 
 ;; Unbound function
 

--- a/test/core/return_call_indirect.wast
+++ b/test/core/return_call_indirect.wast
@@ -508,7 +508,17 @@
   )
   "type mismatch"
 )
-
+(assert_invalid
+  (module
+    (type $ty (func (result i32 i32)))
+    (import "env" "table" (table $table 0 funcref))
+    (func (param i32) (result i32)
+      local.get 0
+      return_call_indirect $table (type $ty)
+    )
+  )
+  "type mismatch"
+)
 
 ;; Unbound type
 

--- a/test/core/return_call_ref.wast
+++ b/test/core/return_call_ref.wast
@@ -374,3 +374,14 @@
   )
   "type mismatch"
 )
+
+(assert_invalid
+  (module
+    (type $ty (func (result i32 i32)))
+    (func (param funcref) (result i32)
+      local.get 0
+      return_call_ref $ty
+    )
+  )
+  "type mismatch"
+)


### PR DESCRIPTION
While a `call $f; return` sequence where `$f` returns more values than its caller is valid so long as the tail of `$f`'s returns match the caller's returns, however that situation is not valid for `return_call $f`. Tail callees must return the exact same number of results as the caller, not more. This case was not previously exercised in any of the spec tests.

Procedural note: I am adding all these tests to the function-references proposal to avoid needing to make multiple PRs to multiple repos because `return_call_ref` was not introduced until this proposal.

@rossberg PTAL